### PR TITLE
Implement linear backoff

### DIFF
--- a/lib/stacker/stack.rb
+++ b/lib/stacker/stack.rb
@@ -182,7 +182,7 @@ JSON
         if changes.empty?
           raise CannotDescribeChangeSet.new 'Empty change set' if retries == 0
           retries -= 1
-          sleep 1
+          sleep (1 * (6 - retries) * 3)
         end
       end
       changes.map do |c|

--- a/lib/stacker/stack.rb
+++ b/lib/stacker/stack.rb
@@ -182,7 +182,7 @@ JSON
         if changes.empty?
           raise CannotDescribeChangeSet.new 'Empty change set' if retries == 0
           retries -= 1
-          sleep (1 * (6 - retries) * 3)
+          sleep ((6 - retries) * 3)
         end
       end
       changes.map do |c|


### PR DESCRIPTION
This seems to work for some deploys that were displaying empty change set and failing earlier