### PR TITLE
Wait for change set to finish completion before proceeding with stack update

### DIFF
--- a/lib/stacker/stack.rb
+++ b/lib/stacker/stack.rb
@@ -184,7 +184,7 @@ JSON
         if ["DELETE_PENDING", "DELETE_IN_PROGRESS", "DELETE_COMPLETE", "DELETE_FAILED", "FAILED"].include? resp_status
           raise CannotDescribeChangeSet.new resp.status_reason
         end
-        if resp_status != "CREATE_COMPLETE" && changes.empty?
+        if resp_status != "CREATE_COMPLETE" || changes.empty?
           puts resp_status
           sleep 1
         end

--- a/lib/stacker/stack.rb
+++ b/lib/stacker/stack.rb
@@ -185,6 +185,23 @@ JSON
           sleep ((6 - retries) * 3)
         end
       end
+      resp_status = ""
+      while resp_status != "CREATE_COMPLETE"
+        resp = region.client.describe_change_set(
+          change_set_name: change_set,
+          stack_name: name,
+          
+        )
+        resp_status = resp.status
+        if resp_status == "FAILED"
+          raise Error.new "Change set failed"
+        end
+        if resp_status != "CREATE_COMPLETE"
+          puts resp_status
+          sleep 1
+        end
+      end
+
       changes.map do |c|
         rc = c.resource_change
         {

--- a/lib/stacker/stack.rb
+++ b/lib/stacker/stack.rb
@@ -173,30 +173,18 @@ JSON
     def describe_change_set
       retries = 6
       changes = []
-      while changes.empty?
-        resp = region.client.describe_change_set(
-          change_set_name: change_set,
-          stack_name: name
-        )
-        changes = resp.changes
-        if changes.empty?
-          raise CannotDescribeChangeSet.new 'Empty change set' if retries == 0
-          retries -= 1
-          sleep ((6 - retries) * 3)
-        end
-      end
       resp_status = ""
-      while resp_status != "CREATE_COMPLETE"
+      while resp_status != "CREATE_COMPLETE" && changes.empty?
         resp = region.client.describe_change_set(
           change_set_name: change_set,
           stack_name: name,
-          
         )
         resp_status = resp.status
+        changes = resp.changes
         if ["DELETE_PENDING", "DELETE_IN_PROGRESS", "DELETE_COMPLETE", "DELETE_FAILED", "FAILED"].include? resp_status
-          raise Error.new resp.status_reason
+          raise CannotDescribeChangeSet.new resp.status_reason
         end
-        if resp_status != "CREATE_COMPLETE"
+        if resp_status != "CREATE_COMPLETE" && changes.empty?
           puts resp_status
           sleep 1
         end

--- a/lib/stacker/stack.rb
+++ b/lib/stacker/stack.rb
@@ -173,7 +173,7 @@ JSON
     def describe_change_set
       changes = []
       resp_status = ""
-      while resp_status != "CREATE_COMPLETE" && changes.empty?
+      while resp_status != "CREATE_COMPLETE"
         resp = region.client.describe_change_set(
           change_set_name: change_set,
           stack_name: name
@@ -183,7 +183,7 @@ JSON
         if ["DELETE_PENDING", "DELETE_IN_PROGRESS", "DELETE_COMPLETE", "DELETE_FAILED", "FAILED"].include? resp_status
           raise CannotDescribeChangeSet.new resp.status_reason
         end
-        if resp_status != "CREATE_COMPLETE" || changes.empty?
+        if resp_status != "CREATE_COMPLETE"
           puts resp_status
           sleep 1
         end

--- a/lib/stacker/stack.rb
+++ b/lib/stacker/stack.rb
@@ -171,7 +171,6 @@ JSON
     end
 
     def describe_change_set
-      retries = 6
       changes = []
       resp_status = ""
       while resp_status != "CREATE_COMPLETE" && changes.empty?

--- a/lib/stacker/stack.rb
+++ b/lib/stacker/stack.rb
@@ -177,7 +177,7 @@ JSON
       while resp_status != "CREATE_COMPLETE" && changes.empty?
         resp = region.client.describe_change_set(
           change_set_name: change_set,
-          stack_name: name,
+          stack_name: name
         )
         resp_status = resp.status
         changes = resp.changes

--- a/lib/stacker/stack.rb
+++ b/lib/stacker/stack.rb
@@ -194,7 +194,7 @@ JSON
         )
         resp_status = resp.status
         if resp_status == "FAILED"
-          raise Error.new "Change set failed"
+          raise Error.new resp.status_reason
         end
         if resp_status != "CREATE_COMPLETE"
           puts resp_status

--- a/lib/stacker/stack.rb
+++ b/lib/stacker/stack.rb
@@ -189,7 +189,6 @@ JSON
           sleep 1
         end
       end
-
       changes.map do |c|
         rc = c.resource_change
         {

--- a/lib/stacker/stack.rb
+++ b/lib/stacker/stack.rb
@@ -193,7 +193,7 @@ JSON
           
         )
         resp_status = resp.status
-        if resp_status == "FAILED"
+        if ["DELETE_PENDING", "DELETE_IN_PROGRESS", "DELETE_COMPLETE", "DELETE_FAILED", "FAILED"].include? resp_status
           raise Error.new resp.status_reason
         end
         if resp_status != "CREATE_COMPLETE"


### PR DESCRIPTION
- Depending on how long a Cloudformation change set takes to finish completion, Stacker can jump the gun on executing a change set, which will fail
- Check if the change set failed and raise the status reason if so