### PR TITLE
[WIP] Sequoia Compatability

### DIFF
--- a/lib/stacker/resolvers/file_parameter_resolver.rb
+++ b/lib/stacker/resolvers/file_parameter_resolver.rb
@@ -1,0 +1,17 @@
+require 'stacker/resolvers/resolver'
+
+module Stacker
+  module Resolvers
+
+    class FileParameterResolver < Resolver
+
+      def resolve
+        parameter_file = region.defaults.fetch 'parameterFile', {}
+        file_vars = YAML.load_file(parameter_file)
+        file_vars[ref]
+      end
+
+    end
+
+  end
+end

--- a/lib/stacker/stack/parameter.rb
+++ b/lib/stacker/stack/parameter.rb
@@ -1,5 +1,6 @@
 require 'stacker/resolvers/stack_output_resolver'
 require 'stacker/resolvers/file_resolver'
+require 'stacker/resolvers/file_parameter_resolver'
 
 module Stacker
   class Stack
@@ -43,7 +44,7 @@ module Stacker
       def resolved
         if dependency?
           begin
-            resolver.resolve
+            Parameter.new(resolver.resolve, region).resolved
           rescue => err
             raise ParameterResolutionError.new value, err
           end

--- a/lib/stacker/stack/parameters.rb
+++ b/lib/stacker/stack/parameters.rb
@@ -18,9 +18,17 @@ module Stacker
         stack.region.defaults.fetch 'parameters', {}
       end
 
-      # template defaults merged with region and stack-specific overrides
+      def region_defaults_file
+        stack.region.defaults.fetch 'parameterFile', {}
+      end
+
+      # template defaults merged with region parameter file, region defaults, and stack-specific overrides
       def local
-        region_defaults = stack.region.defaults.fetch 'parameters', {}
+        if region_defaults_file.empty?
+          region_file_vars = {}
+        else
+          region_file_vars = YAML.load_file(region_defaults_file)
+        end
 
         template_defaults = Hash[
           template_definitions.select { |_, opts|
@@ -31,6 +39,8 @@ module Stacker
         ]
 
         available = template_defaults.merge(
+          region_file_vars
+        ).merge(
           region_defaults
         ).merge(
           stack.options.fetch 'parameters', {}

--- a/stacker.gemspec
+++ b/stacker.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'coderay', '~> 1.1'
   s.add_dependency 'diffy', '~> 3.0'
   s.add_dependency 'indentation', '~> 0.0'
-  s.add_dependency 'jsonlint', '~> 0.2.0'
+  s.add_dependency 'jsonlint', '~> 0.4.0'
   s.add_dependency 'memoist', '~> 0.14'
   s.add_dependency 'rainbow', '~> 1.1'
   s.add_dependency 'thor', '~> 0.18'

--- a/stacker.gemspec
+++ b/stacker.gemspec
@@ -11,16 +11,14 @@ Gem::Specification.new do |s|
   s.files       = Dir['lib/**/*']
   s.executables = Dir['bin/*'].map{ |f| File.basename(f) }
 
-  s.has_rdoc    = false
-
   s.authors     = ['Cotap, Inc.']
   s.email       = %w[martin@cotap.com evan@cotap.com]
   s.homepage    = 'https://github.com/cotap/stacker'
 
-  s.required_ruby_version = '>= 1.9.3'
+  s.required_ruby_version = '>= 2.4'
 
   s.add_dependency 'activesupport', '~> 4.0'
-  s.add_dependency 'aws-sdk', '~> 2.6'
+  s.add_dependency 'aws-sdk', '~> 3'
   s.add_dependency 'coderay', '~> 1.1'
   s.add_dependency 'diffy', '~> 3.0'
   s.add_dependency 'indentation', '~> 0.0'

--- a/stacker.gemspec
+++ b/stacker.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rainbow', '~> 1.1'
   s.add_dependency 'thor', '~> 0.18'
   s.add_dependency 'yamllint', '~> 0.0.9'
+  s.add_dependency 'rexml'
 
   s.add_development_dependency 'rake', '~> 10.4'
   s.add_development_dependency 'rspec-expectations', '~> 3.5'


### PR DESCRIPTION
Ruby 3.0 is not compatible with newer MacOS versions. Psych <4 is not compatible with Ruby >3.0. This should make them play nice.